### PR TITLE
Fix Compile Error

### DIFF
--- a/src/processor.rs
+++ b/src/processor.rs
@@ -100,7 +100,7 @@ pub fn execute(interactive: bool) {
         wsl_cmd = format!(
             "source {};{}",
             translate_path_to_unix(wslexerc_path),
-            interactive ? wsl_args.join(" ") : wsl_args.into_iter().map(shell_escape).collect::<Vec<String>>().join(" ");
+            if interactive { wsl_args.join(" ") }else{ wsl_args.into_iter().map(shell_escape).collect::<Vec<String>>().join(" ")}
         );
     } else {
         wsl_cmd = wsl_args.join(" ");


### PR DESCRIPTION
Fix compile error
```
error: expected token: `,`
   --> src\processor.rs:103:27
    |
103 |             interactive ? wsl_args.join(" ") : wsl_args.into_iter().map(shell_escape).collect::<Vec<String>>().join(" ");
    |                           ^^^^^^^^

error: aborting due to previous error
```
Rust don't have Ternary Conditional Operator. Rust use ? to hande Error and Option.
Use if ... { ... } else { ... } instead.